### PR TITLE
perf: plugin load

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/ape_addressbook/__init__.py
+++ b/ape_addressbook/__init__.py
@@ -1,20 +1,31 @@
 from ape import plugins
-from ape.types import AddressType
-
-from .addressbook import AddressBookConfig, addressbook  # noqa: F401
-from .converters import AddressBookConverter
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from .addresses import AddressBookConfig
+
     return AddressBookConfig
 
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
+    from ape.types import AddressType
+
+    from .converters import AddressBookConverter
+
     return AddressType, AddressBookConverter
 
 
-___all__ = [
-    "addressbook",
-]
+def __getattr__(name: str):
+    if name == "addressbook":
+        from ape_addressbook.addresses import addressbook
+
+        return addressbook
+
+    import ape_addressbook.addresses as module
+
+    return getattr(module, name)
+
+
+___all__ = ["addressbook"]

--- a/ape_addressbook/addresses.py
+++ b/ape_addressbook/addresses.py
@@ -1,17 +1,19 @@
 from collections.abc import Iterator
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from ape.api import PluginConfig
 from ape.logging import logger
-from ape.types import AddressType
 from ape.utils import ManagerAccessMixin
 from eth_utils import is_checksum_address, to_checksum_address
 from pydantic import model_validator
 from pydantic_settings import SettingsConfigDict
 
+if TYPE_CHECKING:
+    from ape.types import AddressType
+
 
 def _validate_entries(entries: dict) -> dict:
-    validated: dict[str, AddressType] = {}
+    validated: dict[str, "AddressType"] = {}
     for k, v in entries.items():
         # Attempt to handle EVM-like addresses but if it fails,
         # let it be in case it is for a more unique ecosystem.
@@ -67,7 +69,7 @@ class AddressBook(ManagerAccessMixin):
         return cast(AddressBookConfig, config_obj)
 
     @property
-    def registry(self) -> dict[str, AddressType]:
+    def registry(self) -> dict[str, "AddressType"]:
         """
         The complete registry of addresses, including both global
         and project addresses.
@@ -91,11 +93,14 @@ class AddressBook(ManagerAccessMixin):
     def __contains__(self, alias: str) -> bool:
         return alias in self.aliases
 
-    def __getitem__(self, alias: str) -> AddressType:
+    def __getitem__(self, alias: str) -> "AddressType":
         if alias not in self.aliases:
             raise IndexError(f"Alias '{alias}' not in addressbook.")
 
         return self.registry[alias]
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self.aliases  # dict like behavior
 
 
 addressbook = AddressBook()

--- a/ape_addressbook/converters.py
+++ b/ape_addressbook/converters.py
@@ -1,14 +1,16 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ape.api.convert import ConverterAPI
-from ape.types import AddressType
 
-from .addressbook import addressbook
+from ape_addressbook import addressbook
+
+if TYPE_CHECKING:
+    from ape.types import AddressType
 
 
 class AddressBookConverter(ConverterAPI):
     def is_convertible(self, value: Any) -> bool:
         return isinstance(value, str) and value in addressbook
 
-    def convert(self, alias: str) -> AddressType:
+    def convert(self, alias: str) -> "AddressType":
         return addressbook[alias]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002,TC003,TC006
 exclude =
 	venv*
 	.eggs
 	docs
 	build
+type-checking-pydantic-enabled = True

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "black>=24.10.0,<25",  # Auto-formatter and linter
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.17",  # Auto-formatter for markdown
+        "mdformat>=0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml


### PR DESCRIPTION
### What I did

Before:

```
In [1]: %time import ape_addressbook
CPU times: user 396 ms, sys: 50.4 ms, total: 446 ms
Wall time: 457 ms
```

After:

```
In [1]: %time import ape_addressbook
CPU times: user 6.89 ms, sys: 2.32 ms, total: 9.22 ms
Wall time: 8.14 ms
```

This one required changing the module name from `ape_addressbook.addressbook` to `ape_addressbook.addresses` because it made `from ape_addressbook import addressbook` always import the module instead of the instance.
There are other bugs when it comes to doing that I have seen in the past so even though it is a little breaky, it doesntt affect the public intended usage of this plugin and fixes a variety of issues so may be worth doing now under that context.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
